### PR TITLE
added Amazon URL product ID parser

### DIFF
--- a/getPriceFromAmazon.py
+++ b/getPriceFromAmazon.py
@@ -1,10 +1,20 @@
 import requests
 import bs4
 
-def getPrice(ProductID):
+def getPrice(URL):
+
+    country_prefix = ""
+
+    if "amazon.de" in URL:
+        country_prefix = "de."
+        URL = URL.replace("/dp/", "/product/")
+
+    URL = URL.replace("?", "/")
+    ProductID = URL.split("/product/", 1)[1].split("/")[0]
+    print(ProductID)
 
     headers = {
-        'authority': 'www.amazon.com',
+        'authority': 'www.camelcamelcamel.com',
         'pragma': 'no-cache',
         'cache-control': 'no-cache',
         'dnt': '1',
@@ -17,6 +27,9 @@ def getPrice(ProductID):
         'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8',
     }
 
-    htmldata = requests.get("https://camelcamelcamel.com/product/" + ProductID, headers=headers)
+    htmldata = requests.get("https://" + country_prefix + "camelcamelcamel.com/product/" + ProductID, headers=headers)
     soup = bs4.BeautifulSoup(htmldata.text, 'html.parser')
-    return soup.find("span", {'class': 'green'}).text
+    try:
+        return soup.find("span", {'class': 'green'}).text
+    except:
+        return False

--- a/getPriceFromAmazon.py
+++ b/getPriceFromAmazon.py
@@ -11,7 +11,6 @@ def getPrice(URL):
 
     URL = URL.replace("?", "/")
     ProductID = URL.split("/product/", 1)[1].split("/")[0]
-    print(ProductID)
 
     headers = {
         'authority': 'www.camelcamelcamel.com',


### PR DESCRIPTION
According to Issue #6 

Now the product ID will be extracted of the whole URL.
Additionally I added a country prefix, because camelcamelcamel.com will only find the product with the right prefix( products from amazon.de => only at de.camelcamelcamel.com)

Maybe in the future the prefix list has do be expanded, depending on the target countries.

In case of a not existing product the function will return False.